### PR TITLE
Fix parameter parsing error message

### DIFF
--- a/src/txtreader.cc
+++ b/src/txtreader.cc
@@ -337,7 +337,7 @@ void txt_reader::read_packet(request_packet* pkt)
 					}
 					else	{
 						m_in->exceptions(excp);
-						msg = MSG_PARAM_MALFORMED + std::string(": ") = line;
+                                                msg = MSG_PARAM_MALFORMED + std::string(": ") + line;
 						throw rqt_reader_exp(msg);
 					}
 				}


### PR DESCRIPTION
## Summary
- correct parameter error message concatenation

## Testing
- `./configure` *(fails: Kit Bematech missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846cf8684e0832a86f07c4f37a125d9