### PR TITLE
Fix typos in README

### DIFF
--- a/README
+++ b/README
@@ -20,7 +20,7 @@ FUNCIONAMENTO:
 
 O spooler ira' recolher arquivos de comando, nomeados de acordo com a mascara
 especificada (normalmente 'arqcmd.*') no diretorio de trabalho especificado.
-O monitoramente e' feito por notificadao do kernel (inotify), portanto, ja' no
+O monitoramento e' feito por notificação do kernel (inotify), portanto, ja' no
 momento que o arquivo for gravado, ja' sera' sinalizado. Assim, e' recomendavel
 que a aplicacao integrada gere arquivos com outro nome, e apenas RENOMEIE para
 o formato da mascara, APOS concluir sua edicao.


### PR DESCRIPTION
## Summary
- fix two typos in the README

## Testing
- `make check` *(fails: No rule to make target `check`)*

------
https://chatgpt.com/codex/tasks/task_e_6846d1718558832a8d8156ff16a702fd