### PR TITLE
Fix mknod error logic

### DIFF
--- a/src/fs.cc
+++ b/src/fs.cc
@@ -46,9 +46,9 @@ void fs::set_umask(mode_t mask) NO_THROW
 bool fs::create_node(const std::string& path, mode_t mode, dev_t dev) 
 	throw(fs_exp)
 {
-	if (mknod(path.c_str(), mode, dev) != -1)   {
-		throw fs_exp(fs::fs_err_msg(errno));
-	}
+       if (mknod(path.c_str(), mode, dev) == -1)   {
+               throw fs_exp(fs::fs_err_msg(errno));
+       }
 
 	return true;
 }


### PR DESCRIPTION
## Summary
- correct failure condition in `fs::create_node`

## Testing
- `./configure` *(fails: Kit Bematech missing)*
- `make` *(fails: No targets and no Makefile)*

------
https://chatgpt.com/codex/tasks/task_e_6846d314c5c0832ab47ace00926dcef0