### PR TITLE
Fix typo in fs comment

### DIFF
--- a/src/fs.cc
+++ b/src/fs.cc
@@ -25,7 +25,7 @@
  \param mask Máscara (conforme man 3p umask).
  \note Deve-se levar em consideração que ao valor de "mask" aplicam-se as
  máscaras (& 0777) para diretórios e (& 0666) para arquivos. Desta forma,
- a invodação de fs::set_umask(022), implicará na criação de arquivos com as
+ a invocação de fs::set_umask(022), implicará na criação de arquivos com as
  permissões 0644 (022 & 0666)
  */
 void fs::set_umask(mode_t mask) NO_THROW


### PR DESCRIPTION
## Summary
- fix a typo in the fs comment describing `fs::set_umask`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6846d3420bcc832abdaa8c096714e362