### PR TITLE
Add minimal fs test

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,7 @@
 
 AUTOMAKE_OPTIONS = gnu
 ACLOCAL_AMFLAGS = -I m4
-SUBDIRS = src utils/rc4_crypt man
+SUBDIRS = src utils/rc4_crypt man tests
 EXTRA_DIST = man/rc4_crypt.pod \
 				man/spooler.cfg.pod \
 				man/spooler.pod

--- a/Makefile.in
+++ b/Makefile.in
@@ -244,7 +244,7 @@ top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AUTOMAKE_OPTIONS = gnu
 ACLOCAL_AMFLAGS = -I m4
-SUBDIRS = src utils/rc4_crypt man
+SUBDIRS = src utils/rc4_crypt man tests
 EXTRA_DIST = man/rc4_crypt.pod \
 				man/spooler.cfg.pod \
 				man/spooler.pod

--- a/src/fs.cc
+++ b/src/fs.cc
@@ -43,14 +43,14 @@ void fs::set_umask(mode_t mask) NO_THROW
  \returns Valor lógico, indicando sucesso ou falha na operação.
  \throws fs_exp Caso ocorra algum erro de syscall.
  */
-bool fs::create_node(const std::string& path, mode_t mode, dev_t dev) 
-	throw(fs_exp)
+bool fs::create_node(const std::string& path, mode_t mode, dev_t dev)
+       throw(fs_exp)
 {
-	if (mknod(path.c_str(), mode, dev) != -1)   {
-		throw fs_exp(fs::fs_err_msg(errno));
-	}
+       if (mknod(path.c_str(), mode, dev) == -1)   {
+               throw fs_exp(fs::fs_err_msg(errno));
+       }
 
-	return true;
+       return true;
 }
 
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,15 @@
+CXX = g++
+CXXFLAGS = -Wall -g -std=c++11 -I../src
+
+all: test_fs
+
+test_fs: test_fs.cpp ../src/fs.cc gtest/gtest.h
+	$(CXX) $(CXXFLAGS) -o $@ test_fs.cpp ../src/fs.cc
+
+check: test_fs
+	./test_fs
+
+clean:
+	rm -f test_fs *.o
+
+.PHONY: all check clean

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,0 +1,10 @@
+check_PROGRAMS = test_fs
+TESTS = $(check_PROGRAMS)
+
+AM_CPPFLAGS = -I$(top_srcdir)/src
+
+# Include custom gtest-lite header
+nodist_test_fs_SOURCES = gtest/gtest.h
+
+test_fs_SOURCES = test_fs.cpp $(top_srcdir)/src/fs.cc
+

--- a/tests/gtest/gtest.h
+++ b/tests/gtest/gtest.h
@@ -1,0 +1,39 @@
+#ifndef GTEST_LITE_H
+#define GTEST_LITE_H
+#include <iostream>
+#include <vector>
+#include <functional>
+
+namespace testing {
+struct TestCase { std::string name; std::function<void()> func; };
+inline std::vector<TestCase>& get_tests() { static std::vector<TestCase> v; return v; }
+inline int tests_failed = 0;
+}
+
+#define TEST(tc, tn) \
+void tc##_##tn##_func(); \
+struct tc##_##tn##_registrar { \
+    tc##_##tn##_registrar() { ::testing::get_tests().push_back({#tc "." #tn, tc##_##tn##_func}); } \
+} tc##_##tn##_instance; \
+void tc##_##tn##_func()
+
+#define EXPECT_TRUE(cond) \
+do { if(!(cond)) { std::cerr << __FILE__ << ":" << __LINE__ << ": Failure EXPECT_TRUE(" #cond ")\n"; ::testing::tests_failed++; } } while(0)
+
+#define EXPECT_EQ(exp, act) \
+do { if(!((exp) == (act))) { std::cerr << __FILE__ << ":" << __LINE__ << ": Failure EXPECT_EQ\nExpected: " << (exp) << "\nActual: " << (act) << "\n"; ::testing::tests_failed++; } } while(0)
+
+inline int RUN_ALL_TESTS() {
+    for(auto& t : ::testing::get_tests()) {
+        std::cout << "[ RUN      ] " << t.name << std::endl;
+        t.func();
+    }
+    if(::testing::tests_failed==0) {
+        std::cout << "[  PASSED  ] " << ::testing::get_tests().size() << " tests." << std::endl;
+    } else {
+        std::cout << "[  FAILED  ] " << ::testing::tests_failed << " tests." << std::endl;
+    }
+    return ::testing::tests_failed==0 ? 0 : 1;
+}
+
+#endif // GTEST_LITE_H

--- a/tests/test_fs.cpp
+++ b/tests/test_fs.cpp
@@ -1,0 +1,36 @@
+#include "gtest/gtest.h"
+#include "../src/fs.h"
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+TEST(FS, CreateFifoSuccess) {
+    const char* path = "test_fifo";
+    ::unlink(path);
+    bool created = false;
+    try {
+        created = fs::create_node(path, S_IFIFO | 0600, 0);
+    } catch(const fs_exp&) {
+        created = false;
+    }
+    EXPECT_TRUE(created);
+    struct stat st{};
+    EXPECT_EQ(0, ::stat(path, &st));
+    EXPECT_TRUE((st.st_mode & S_IFIFO) == S_IFIFO);
+    EXPECT_EQ(0600, st.st_mode & 0777);
+    ::unlink(path);
+}
+
+TEST(FS, CreateNodeInvalidPath) {
+    bool created = true;
+    try {
+        created = fs::create_node("/invalid_path/does_not_exist/file", S_IFIFO | 0600, 0);
+    } catch(const fs_exp&) {
+        created = false;
+    }
+    EXPECT_TRUE(!created);
+}
+
+int main() {
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- add custom gtest-lite harness and FS tests
- enable `tests` directory in build
- fix `fs::create_node` to throw only on error
- provide simple Makefile for compiling the tests

## Testing
- `make` inside tests directory
- `make check` inside tests directory

------
https://chatgpt.com/codex/tasks/task_e_6846d35b2110832ab11e58998b6ee2cd